### PR TITLE
bulk add demo

### DIFF
--- a/benchmarks/bench_all.nim
+++ b/benchmarks/bench_all.nim
@@ -15,6 +15,18 @@ separator()
 
 # Pairings
 when BLS_BACKEND == BLST:
+  benchEcBulkAddG1(10, 10)
+  benchEcBulkAddG2(10, 10)
+  benchEcBulkAddG1(100, 10)
+  benchEcBulkAddG2(100, 10)
+  benchEcBulkAddG1(1000, 10)
+  benchEcBulkAddG2(1000, 10)
+  benchEcBulkAddG1(10000, 10)
+  benchEcBulkAddG2(10000, 10)
+  benchEcBulkAddG1(100000, 10)
+  benchEcBulkAddG2(100000, 10)
+  benchEcBulkAddG1(1000000, 10)
+  benchEcBulkAddG2(1000000, 10)
   benchBLSTPairing(1000)
 else:
   benchMiraclPairingViaDoublePairing(1000)

--- a/benchmarks/bls12381_curve.nim
+++ b/benchmarks/bls12381_curve.nim
@@ -115,6 +115,30 @@ proc benchECAddG2*(iters: int) =
 
 when BLS_BACKEND == BLST:
 
+  proc benchECbulkAddG1*(numPoints, iters: int) =
+    var ps = newSeq[blst_p1_affine](numPoints)
+    for i in 0 ..< ps.len:
+      # Fill with generator, BLST handles doubling without branching
+      ps[i] = BLS12_381_G1
+    
+    var r{.noInit.}: blst_p1
+    let ps0 = ps[0].addr
+    let ps00 = ps0.unsafeAddr # Weird API with double indirection
+    bench("EC bulk add G1 - " & $numPoints, iters):
+      r.blst_p1s_add(ps00, ps.len)
+
+  proc benchECbulkAddG2*(numPoints, iters: int) =
+    var ps = newSeq[blst_p2_affine](numPoints)
+    for i in 0 ..< ps.len:
+      # Fill with generator, BLST handles doubling without branching
+      ps[i] = BLS12_381_G2
+
+    var r{.noInit.}: blst_p2
+    let ps0 = ps[0].addr
+    let ps00 = ps0.unsafeAddr # Weird API with double indirection
+    bench("EC bulk add G2 - " & $numPoints, iters):
+      r.blst_p2s_add(ps00, ps.len)
+
   proc benchBLSTPairing*(iters: int) =
     let (pubkey, seckey) = block:
       var pk: PublicKey
@@ -239,6 +263,23 @@ when isMainModule:
   benchEcAddG2(1000)
 
   when BLS_BACKEND == BLST:
+    benchEcBulkAddG1(10, 10)
+    benchEcBulkAddG2(10, 10)
+    benchEcBulkAddG1(100, 10)
+    benchEcBulkAddG2(100, 10)
+    benchEcBulkAddG1(1000, 10)
+    benchEcBulkAddG2(1000, 10)
+    benchEcBulkAddG1(1024, 10)
+    benchEcBulkAddG2(1024, 10)
+    benchEcBulkAddG1(2048, 10)
+    benchEcBulkAddG2(2048, 10)
+    benchEcBulkAddG1(10000, 10)
+    benchEcBulkAddG2(10000, 10)
+    benchEcBulkAddG1(100000, 10)
+    benchEcBulkAddG2(100000, 10)
+    benchEcBulkAddG1(1000000, 10)
+    benchEcBulkAddG2(1000000, 10)
+
     benchBLSTPairing(5000)
   else:
     benchMiraclPairingViaDoublePairing(1000)

--- a/blscurve/blst/blst_abi.nim
+++ b/blscurve/blst/blst_abi.nim
@@ -107,7 +107,7 @@ type
     y*: blst_fp
     z*: blst_fp
 
-  blst_p1_affine* {.byref.} = object
+  blst_p1_affine* {.blst, byref.} = object
     x*: blst_fp
     y*: blst_fp
 
@@ -116,7 +116,7 @@ type
     y*: blst_fp2
     z*: blst_fp2
 
-  blst_p2_affine* {.byref.} = object
+  blst_p2_affine* {.blst, byref.} = object
     x*: blst_fp2
     y*: blst_fp2
 
@@ -125,7 +125,7 @@ type
     e1: blst_p1
     e2: blst_p2
 
-  blst_pairing* = object
+  blst_pairing* {.byref.} = object
     # "blst_pairing" in header is defined as
     # an empty struct. This forces usage on the heap
     # through pointer.
@@ -259,6 +259,9 @@ proc blst_p1_affine_is_equal*(a: blst_p1_affine; b: blst_p1_affine): CTbool
 proc blst_p1_affine_is_inf*(a: blst_p1_affine): CTbool
 proc blst_p1_generator*(): ptr blst_p1
 
+# Bulk addition G1 - TODO ptr ptr UncheckedArray[blst_p1_affine]
+proc blst_p1s_add*(sum: var blst_p1, points: ptr ptr blst_p1_affine, npoints: int)
+
 # BLS12-381-specific G2 operations.
 proc blst_p2_add*(dst: var blst_p2; a: blst_p2; b: blst_p2)
 proc blst_p2_add_or_double*(dst: var blst_p2; a: blst_p2; b: blst_p2)
@@ -278,6 +281,9 @@ proc blst_p2_affine_in_g2*(p: blst_p2_affine): CTbool
 proc blst_p2_affine_is_equal*(a: blst_p2_affine; b: blst_p2_affine): CTbool
 proc blst_p2_affine_is_inf*(a: blst_p2_affine): CTbool
 proc blst_p2_generator*(): ptr blst_p2
+
+# Bulk addition G2 - TODO ptr ptr UncheckedArray[blst_p2_affine]
+proc blst_p2s_add*(sum: var blst_p2, points: ptr ptr blst_p2_affine, npoints: int)
 
 # Hash-to-curve operations.
 proc blst_map_to_g1*(dst: var blst_p1; u: blst_fp; v: blst_fp)


### PR DESCRIPTION
Demo for devcon cc @asn-d6

```
Compiled with GCC
Optimization level => no optimization: false | release: true | danger: true
Running on 11th Gen Intel(R) Core(TM) i9-11980HK @ 2.60GHz


⚠️ Cycles measurements are approximate and use the CPU nominal clock: Turbo-Boost and overclocking will skew them.
i.e. a 20% overclock will be about 20% off (assuming no dynamic frequency scaling)

Backend: BLST, mode: 64-bit
====================================================================================================================================

Scalar multiplication G1 (255-bit, constant-time)                             10273.058 ops/s        97342 ns/op       321460 cycles
Scalar multiplication G2 (255-bit, constant-time)                              4501.341 ops/s       222156 ns/op       733647 cycles
EC add G1 (constant-time)                                                   1923076.923 ops/s          520 ns/op         1717 cycles
EC add G2 (constant-time)                                                    688231.246 ops/s         1453 ns/op         4798 cycles
EC bulk add G1 - 10                                                          244259.893 ops/s         4094 ns/op        13512 cycles
EC bulk add G2 - 10                                                           94348.523 ops/s        10599 ns/op        34992 cycles
EC bulk add G1 - 100                                                          29748.624 ops/s        33615 ns/op       111005 cycles
EC bulk add G2 - 100                                                          12546.579 ops/s        79703 ns/op       263202 cycles
EC bulk add G1 - 1000                                                          3880.797 ops/s       257679 ns/op       850947 cycles
EC bulk add G2 - 1000                                                          1464.804 ops/s       682685 ns/op      2254472 cycles
EC bulk add G1 - 1024                                                          3541.152 ops/s       282394 ns/op       932569 cycles
EC bulk add G2 - 1024                                                          1449.244 ops/s       690015 ns/op      2278671 cycles
EC bulk add G1 - 2048                                                          1906.930 ops/s       524403 ns/op      1731767 cycles
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
```
![image](https://user-images.githubusercontent.com/22738317/197404212-f623cd94-239e-4ff7-91e1-b88a4028d315.png)


As mentioned, there is a crash in BLST currently if we go over 2048 G1 points or 1024 G2 points, unsure why but BLST batches addition 2048 by 2048 or 1024 by 1024 ( https://github.com/supranational/blst/blob/6382d67/src/bulk_addition.c#L148-L149 ) so the benchmark scales linearly to a million points